### PR TITLE
Change install_kubectl to install_path

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GIT
 PATH
   remote: .
   specs:
-    vagrant-rke2 (0.1.1)
+    vagrant-rke2 (0.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ Vagrant.configure("2") do |config|
     rke2.config_mode = '0644' # side-step https://github.com/k3s-io/k3s/issues/4321
     rke2.config_owner = 'root:root' #default
 
-    # install_kubectl: QOL feature, installs latest version of kubectl
+    # install_path: QOL feature, add RKE2 to the PATH and points the KUBECONFIG to rke2.yaml
     # type => Boolean
     # default => true
-    rke2.install_kubectl = false
+    rke2.install_path = false
   end
 end
 ```

--- a/lib/vagrant-rke2/config.rb
+++ b/lib/vagrant-rke2/config.rb
@@ -55,7 +55,7 @@ module VagrantPlugins
   
         # Defaults to true
         # @return [Boolean]
-        attr_accessor :install_kubectl
+        attr_accessor :install_path
 
         def initialize
           @config = UNSET_VALUE
@@ -67,7 +67,7 @@ module VagrantPlugins
           @env_owner = UNSET_VALUE
           @env_path = UNSET_VALUE
           @installer_url = UNSET_VALUE
-          @install_kubectl = UNSET_VALUE
+          @install_path = UNSET_VALUE
         end
   
         def finalize!
@@ -80,7 +80,7 @@ module VagrantPlugins
           @env_owner = DEFAULT_ENV_OWNER if @env_owner == UNSET_VALUE
           @env_path = DEFAULT_ENV_PATH if @env_path == UNSET_VALUE
           @installer_url = DEFAULT_INSTALLER_URL_LINUX if @installer_url == UNSET_VALUE
-          @install_kubectl = true if @install_kubectl == UNSET_VALUE
+          @install_path = true if @install_path == UNSET_VALUE
         end
   
         def validate(machine)

--- a/lib/vagrant-rke2/version.rb
+++ b/lib/vagrant-rke2/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Rke2
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -2,8 +2,11 @@ ENV['VAGRANT_I_KNOW_WHAT_IM_DOING_PLEASE_BE_QUIET'] = 'true'
 Vagrant.require_version ">= 2.2.17"
 
 Vagrant.configure("2") do |config|
-  config.vagrant.plugins = ["vagrant-reload", "vagrant-rke2"]
-  
+  # For user example 
+  # config.vagrant.plugins = ["vagrant-reload", "vagrant-rke2"]
+  # For dev work
+  config.vagrant.plugins = ["vagrant-reload"]
+
 
   config.vm.provider "virtualbox" do |v|
     v.cpus = 2         


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

Realized that kubectl is already installed by RKE2, just not available via the path. Changed the QOL option to simply expose the existing kubectl

Version bump to v0.1.2