### PR TITLE
Increase memory

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -10,12 +10,12 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider "libvirt" do |v|
     v.cpus = 2         
-    v.memory = 2048
+    v.memory = 4096
   end
 
   config.vm.provider "virtualbox" do |v|
     v.cpus = 2         
-    v.memory = 2048
+    v.memory = 4096
     v.linked_clone = true
   end
 


### PR DESCRIPTION
Without this PR, we get errors in the server when deploying rke2 1.24:

  Warning  FailedScheduling  64s   default-scheduler  0/1 nodes are available: 1 Insufficient memory, 1 node(s) had untolerated taint {node.cloudprovider.kubernetes.io/uninitialized: true}. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.


Signed-off-by: Manuel Buil <mbuil@suse.com>