### PR TITLE
Use "restart" verb instead of "start"

### DIFF
--- a/lib/vagrant-rke2/provisioner.rb
+++ b/lib/vagrant-rke2/provisioner.rb
@@ -95,14 +95,14 @@ module VagrantPlugins
         if !service.empty?
           @machine.communicate.sudo("systemctl enable rke2-#{service}.service")
           if !config.skip_start
-            @machine.communicate.sudo("systemctl start rke2-#{service}.service") do |type, line|
+            @machine.communicate.sudo("systemctl restart rke2-#{service}.service") do |type, line|
               @machine.ui.detail line, :color => :yellow
             end
           end
         else
           @machine.communicate.sudo("systemctl enable rke2-server.service")
           if !config.skip_start 
-            @machine.communicate.sudo("systemctl start rke2-server.service") do |type, line|
+            @machine.communicate.sudo("systemctl restart rke2-server.service") do |type, line|
               @machine.ui.detail line, :color => :yellow
             end
           end


### PR DESCRIPTION
The upgrade test does not complete the upgrade because the rke2 systemd unit is never restarted and thus it remains using the old version.

This PR changes the "systemctl start $SERVICE" command with "systemctl restart $SERVICE". If the service was not started, it will have the same result as "start" and if the service was already started, it will restart it hence fixing the upgrade test case